### PR TITLE
Add VPC & more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# terraform
+
+# compiled files
+*.tfstate
+*.tfstate.backup
+.terraform.tfstate.lock.info
+
+# module directory
+.terraform/
+
+crash.log
+crash.*.log
+
+*.tfvars
+*.tfvars.json
+
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+.terraformrc
+terraform.rc
+.terraform.lock.hcl

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,4 @@
+module "vpc" {
+  source            = "./modules/vpc"
+  availability_zone = var.region // Automatically adds a & b for public and private
+}

--- a/terraform/modules/vpc/README.md
+++ b/terraform/modules/vpc/README.md
@@ -1,0 +1,45 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_eip.eip_ngw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
+| [aws_internet_gateway.igw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
+| [aws_nat_gateway.ngw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway) | resource |
+| [aws_route_table.private_rt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
+| [aws_route_table.public_rt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
+| [aws_route_table_association.private-rta](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.public-rt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_vpc.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | The availability zone to use for both the public and private subnets | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_internet_gateway_id"></a> [internet\_gateway\_id](#output\_internet\_gateway\_id) | Internet Gateway ID |
+| <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | List of private subnet IDs |
+| <a name="output_public_subnet_ids"></a> [public\_subnet\_ids](#output\_public\_subnet\_ids) | List of public subnet IDs |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The VPC ID |
+<!-- END_TF_DOCS -->

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -1,0 +1,88 @@
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "main"
+  }
+}
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "main-gw"
+  }
+}
+
+locals {
+  availability_zone_a = "${var.availability_zone}a"
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(aws_vpc.main.cidr_block, 8, 1)
+  map_public_ip_on_launch = true
+  availability_zone       = local.availability_zone_a
+
+  tags = {
+    Name = "subnet1"
+  }
+}
+
+resource "aws_subnet" "private" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(aws_vpc.main.cidr_block, 8, 2)
+  map_public_ip_on_launch = false
+  availability_zone       = local.availability_zone_a
+
+  tags = {
+    Name = "subnet2"
+  }
+}
+
+resource "aws_eip" "eip_ngw" {
+  count = 1
+}
+
+resource "aws_nat_gateway" "ngw" {
+  connectivity_type = "public"
+  subnet_id         = aws_subnet.public.id
+  allocation_id     = aws_eip.eip_ngw[0].id
+}
+
+resource "aws_route_table" "private_rt" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.ngw.id
+  }
+
+  tags = {
+    Name = "private-outgoing-rt"
+  }
+}
+
+resource "aws_route_table_association" "private-rta" {
+  subnet_id      = aws_subnet.private.id
+  route_table_id = aws_route_table.private_rt.id
+}
+
+resource "aws_route_table" "public_rt" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
+
+  tags = {
+    Name = "public-ingoing-outgoing-rt"
+  }
+}
+
+resource "aws_route_table_association" "public-rt" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public_rt.id
+}

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -1,0 +1,19 @@
+output "vpc_id" {
+  description = "The VPC ID"
+  value       = aws_vpc.main.id
+}
+
+output "public_subnet_ids" {
+  description = "List of public subnet IDs"
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  value       = aws_subnet.private[*].id
+}
+
+output "internet_gateway_id" {
+  description = "Internet Gateway ID"
+  value       = aws_internet_gateway.igw.id
+}

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -1,0 +1,4 @@
+variable "availability_zone" {
+  type        = string
+  description = "The availability zone to use for both the public and private subnets"
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.14.0"
+    }
+  }
+
+  backend "s3" {
+    bucket  = "csfloat-notifier-terraform-state"
+    key     = "terraform.tfstate"
+    region  = "eu-west-2"
+    encrypt = true
+  }
+}
+
+provider "aws" {
+  shared_config_files = ["~/.aws/credentials"]
+  profile             = "default"
+  region              = "eu-west-2"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,5 @@
+variable "region" {
+  description = "AWS region to deploy resources"
+  type        = string
+  default     = "eu-west-2"
+}


### PR DESCRIPTION
# Description
Adds a VPC with:
- IGW
- Public & Private subnets in one AZ
- NGW with 1 EIP placed in public subnet for outgoing private subnet traffic
- Public & Private route tables

# Testing
Running `terraform plan` works as expected.