### PR TITLE
Add security group

### DIFF
--- a/terraform/modules/security-group/main.tf
+++ b/terraform/modules/security-group/main.tf
@@ -1,0 +1,25 @@
+// A TLS connection is HTTPS
+resource "aws_security_group" "allow_tls" {
+  name        = "allow_tls"
+  description = "Allow TLS inbound traffic"
+  vpc_id      = var.aws_vpc_id
+
+  ingress {
+    description = "TLS ingress"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "allow_tls"
+  }
+}

--- a/terraform/modules/security-group/variables.tf
+++ b/terraform/modules/security-group/variables.tf
@@ -1,0 +1,4 @@
+variable "aws_vpc_id" {
+  description = "The VPC ID where the security group will be created"
+  type        = string
+}


### PR DESCRIPTION
# Description
Adds a general security group module which only allows TLS ingress and disallows all other egress.

# Testing
Running `terraform plan` works as expected.