### PR TITLE
Add WAF

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,3 +2,10 @@ module "vpc" {
   source            = "./modules/vpc"
   availability_zone = var.region // Automatically adds a & b for public and private
 }
+
+module "cloudwatch" {
+  source                          = "./modules/cloudwatch"
+  waf_log_group_name              = "waf-log-group-${var.region}"
+  waf_log_group_retention_in_days = 30
+  tags                            = {}
+}

--- a/terraform/modules/cloudwatch/main.tf
+++ b/terraform/modules/cloudwatch/main.tf
@@ -1,0 +1,4 @@
+resource "aws_cloudwatch_log_group" "waf_log_group" {
+  name              = var.waf_log_group_name
+  retention_in_days = var.waf_log_group_retention_in_days
+}

--- a/terraform/modules/cloudwatch/outputs.tf
+++ b/terraform/modules/cloudwatch/outputs.tf
@@ -1,0 +1,4 @@
+output "waf_log_group_arn" {
+  description = "The ARN of the WAF CloudWatch Log Group"
+  value       = aws_cloudwatch_log_group.waf_log_group.arn
+}

--- a/terraform/modules/cloudwatch/variables.tf
+++ b/terraform/modules/cloudwatch/variables.tf
@@ -1,0 +1,16 @@
+variable "waf_log_group_name" {
+  type        = string
+  description = "The name of the CloudWatch Log Group for WAF logs"
+}
+
+variable "waf_log_group_retention_in_days" {
+  type        = number
+  description = "The retention period in days for the WAF CloudWatch Log Group"
+  default     = 30
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "A map of tags to assign to the WAF CloudWatch Log Group"
+  default     = {}
+}

--- a/terraform/modules/waf/main.tf
+++ b/terraform/modules/waf/main.tf
@@ -1,0 +1,50 @@
+resource "aws_wafv2_web_acl" "main" {
+  name        = var.waf_name
+  description = "WAF web ACL for ALB" // Access Control List for Application Load Balancer
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "common-rules"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${var.waf_name}-blocked-common-rules"
+      sampled_requests_enabled   = false // Does not store full requests in CloudWatch Logs
+    }
+  }
+
+  tags = var.tags
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "${var.waf_name}-allowed"
+    sampled_requests_enabled   = false
+  }
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "main" {
+  log_destination_configs = [var.waf_log_group_arn]
+  resource_arn            = aws_wafv2_web_acl.main.arn
+  redacted_fields {
+    // TODO: add authentication headers here if necessary
+    single_header {
+      name = "user-agent"
+    }
+  }
+}

--- a/terraform/modules/waf/variables.tf
+++ b/terraform/modules/waf/variables.tf
@@ -1,0 +1,15 @@
+variable "waf_name" {
+  type        = string
+  description = "The name of the WAF Web ACL"
+}
+
+variable "waf_log_group_arn" {
+  type        = string
+  description = "The ARN of the CloudWatch Log Group for WAF logs"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "A map of tags to assign to the WAF Web ACL"
+  default     = {}
+}


### PR DESCRIPTION
# Description
Adds a WAF (Web Application Firewall) including logging for blocked requests using cloudwatch.
Blocked logs based off the rule `AWSManagedRulesCommonRuleSet` will be logged in cloudwatch under `{waf-name}-blocked-common-rules`
# Testing
Running `terraform plan` works.