### PR TITLE
Add ecs fargate

### DIFF
--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -1,0 +1,53 @@
+locals {
+  container_cpu    = var.cpu / 2
+  container_memory = var.memory / 2
+}
+
+resource "aws_ecs_cluster" "main" {
+  name = "${var.container_name}-${var.environment}-cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+}
+
+resource "aws_ecs_task_definition" "service" {
+  family = "${var.container_name}-${var.environment}-task"
+
+  cpu                      = var.cpu
+  memory                   = var.memory
+  network_mode             = "awsvpc"
+  execution_role_arn       = var.execution_role_arn
+  requires_compatibilities = ["FARGATE"]
+
+  container_definitions = templatefile("./templates/ecs/app.tftpl", {
+    container_name  = "${var.container_name}-${var.environment}-container"
+    container_image = var.container_image
+    cpu             = local.container_cpu
+    memory          = local.container_memory
+    app_port        = var.container_port
+    aws_region      = var.region
+    environment     = var.environment
+  })
+}
+
+resource "aws_ecs_service" "main" {
+  name            = "${var.container_name}-${var.environment}-service"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.service.arn
+  desired_count   = var.task_count
+  launch_type     = "FARGATE"
+
+  load_balancer {
+    target_group_arn = var.target_group_arn
+    container_name   = "${var.container_name}-${var.environment}-container"
+    container_port   = var.container_port
+  }
+
+  network_configuration {
+    security_groups  = var.security_group_ids
+    subnets          = var.subnet_ids
+    assign_public_ip = true
+  }
+}

--- a/terraform/modules/ecs/outputs.tf
+++ b/terraform/modules/ecs/outputs.tf
@@ -1,0 +1,15 @@
+output "cluster_name" {
+  value = aws_ecs_cluster.main.name
+}
+
+output "cluster_arn" {
+  value = aws_ecs_cluster.main.arn
+}
+
+output "service_name" {
+  value = aws_ecs_service.main.name
+}
+
+output "service_arn" {
+  value = aws_ecs_service.main.arn
+}

--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -1,0 +1,61 @@
+variable "container_name" {
+  type    = string
+  default = "csfloat-notifier"
+}
+
+variable "environment" {
+  description = "Environment name (e.g., dev, staging, prod)"
+  type        = string
+  default     = "dev"
+}
+
+variable "cpu" {
+  description = "The number of CPU units used by the task."
+  type        = number
+}
+
+variable "memory" {
+  description = "The amount of memory (in MiB) used by the task."
+  type        = number
+}
+
+variable "execution_role_arn" {
+  description = "The ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume."
+  type        = string
+}
+
+variable "container_image" {
+  description = "The Docker image for the application container."
+  type        = string
+}
+
+variable "container_port" {
+  description = "The port on which the application container listens."
+  type        = number
+}
+
+variable "region" {
+  description = "The AWS region where resources will be created."
+  type        = string
+}
+
+variable "task_count" {
+  description = "The desired number of instantiations of the task definition to run on the service."
+  type        = number
+  default     = 1
+}
+
+variable "target_group_arn" {
+  description = "The ARN of the load balancer target group to associate with the service."
+  type        = string
+}
+
+variable "security_group_ids" {
+  description = "A list of security group IDs to associate with the service."
+  type        = list(string)
+}
+
+variable "subnet_ids" {
+  description = "A list of subnet IDs to associate with the service."
+  type        = list(string)
+}

--- a/terraform/templates/ecs/app.tftpl
+++ b/terraform/templates/ecs/app.tftpl
@@ -1,0 +1,29 @@
+[
+    {
+        "name": "${container_name}",
+        "image": "${container_image}",
+        "cpu": ${cpu},
+        "memory": ${memory},
+        "networkMode": "awsvpc",
+        "portMappings": [
+            {
+                "containerPort": ${app_port},
+                "hostPort": ${app_port},
+                "protocol": "tcp"
+            }
+        ],
+        "essential": true,
+        "environment": [],
+        "secrets": [],
+        "user": "",
+        "readonlyRootFilesystem": true,
+        "logConfiguration": {
+            "logDriver": "awslogs",
+            "options": {
+                "awslogs-group": "/ecs/${container_name}-${environment}",
+                "awslogs-region": "${aws_region}",
+                "awslogs-stream-prefix": "ecs"
+            }
+        }
+    }
+]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -9,3 +9,39 @@ variable "container_name" {
   type        = string
   default     = "main-container"
 }
+
+variable "container_image" {
+  description = "Docker image to deploy"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (e.g., dev, staging, prod)"
+  type        = string
+  default     = "dev"
+}
+
+variable "task_count" {
+  description = "Number of ECS tasks to run"
+  type        = number
+  default     = 2
+}
+
+
+variable "container_port" {
+  description = "Port the container listens on"
+  type        = number
+  default     = 5000
+}
+
+variable "cpu" {
+  description = "CPU units for the ECS task"
+  type        = number
+  default     = 256
+}
+
+variable "memory" {
+  description = "Memory (in MiB) for the ECS task"
+  type        = number
+  default     = 512
+}


### PR DESCRIPTION
# Description
Adds an ECS module which creates a fargate ecs instance from a template `.tftpl` file. 

# Testing
Running `terraform plan` outputs the correct structure.
